### PR TITLE
force utf-8 encoding

### DIFF
--- a/lib/dress_code/renderer.rb
+++ b/lib/dress_code/renderer.rb
@@ -5,6 +5,7 @@ require_relative '../dress_code'
 class DressCode::Renderer < Redcarpet::Render::HTML
 
   def block_code(code, language)
+    code.force_encoding('utf-8')
     syntax = Pygments.highlight(code, {
       lexer: language,
       options: { encoding: 'utf-8' }


### PR DESCRIPTION
Just in case somebody (_cough_) gets an error like this: https://gist.github.com/aaronshaf/65ff7025fd552f58abee/raw/70d293df80992534c1c6a8ed2a81a44bbbc4c98e/gistfile1.txt
